### PR TITLE
Move ci logic in configure for sharing with Coq upstream CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,7 @@ before_install:
 
 script:
 - echo 'Building GeoCoq...' && echo -en 'travis_fold:start:geocoq.build\\r'
-- cp -f Make.in Make
-- find . -name "*.v" | grep -v Sandbox >> Make
-# We lack a few minutes to be able to build the whole library.
-- sed -i.bak '/Ch16_coordinates_with_functions\.v/d'             Make
-- sed -i.bak '/Elements\/Statements\/Book_1\.v/d'                Make
-- sed -i.bak '/Elements\/Statements\/Book_3\.v/d'                Make
-- sed -i.bak '/main.v/d'                                         Make
-- coq_makefile -f Make -o Makefile
+- ./configure-ci.sh
 - make -j 2
 # travis_wait allows more minutes without output, usefull for long automatic proofs
 - echo -en 'travis_fold:end:geocoq.build\\r'

--- a/configure-ci.sh
+++ b/configure-ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+cp -f Make.in Make
+find . -name "*.v" | grep -v Sandbox >> Make
+
+# We lack a few minutes to be able to build the whole library.
+sed -i.bak '/Ch16_coordinates_with_functions\.v/d'             Make
+sed -i.bak '/Elements\/Statements\/Book_1\.v/d'                Make
+sed -i.bak '/Elements\/Statements\/Book_3\.v/d'                Make
+sed -i.bak '/main.v/d'                                         Make
+
+coq_makefile -f Make -o Makefile


### PR DESCRIPTION
Recent changes to `.travis.yml` were not reflected in Coq's `.travis.yml`. Then the builds on Coq CI broke but this went unnoticed on the GeoCoq side whose CI was still passing. This change is to avoid this problem in the future, by moving the CI to a place where it can be shared between the two CI (in `configure.sh`).

Prepared with @SkySkimmer (thanks!)