### PR TITLE
Attempt to fix #8: GeoCoq compilation too long on Travis.

### DIFF
--- a/configure-ci.sh
+++ b/configure-ci.sh
@@ -4,6 +4,11 @@ find . -name "*.v" | grep -v Sandbox >> Make
 
 # We lack a few minutes to be able to build the whole library.
 sed -i.bak '/Ch16_coordinates_with_functions\.v/d'             Make
+sed -i.bak '/Elements\/OriginalProofs\/proposition_30\.v/d'    Make
+sed -i.bak '/Elements\/OriginalProofs\/proposition_44A\.v/d'   Make
+sed -i.bak '/Elements\/OriginalProofs\/proposition_44\.v/d'    Make
+sed -i.bak '/Elements\/OriginalProofs\/proposition_45\.v/d'    Make
+sed -i.bak '/Elements\/OriginalProofs\/book1\.v/d'             Make
 sed -i.bak '/Elements\/Statements\/Book_1\.v/d'                Make
 sed -i.bak '/Elements\/Statements\/Book_3\.v/d'                Make
 sed -i.bak '/main.v/d'                                         Make


### PR DESCRIPTION
This is a proposal to close #8. It removes a few minutes of compilation time (2 minutes of sequential compilation time). @ejgallego Do you think it will be enough? Note that I did this solely based on compilation time and do not pretend to know this library well. @jnarboux Feel free to adapt to something more sensible.