### PR TITLE
Avoid relying on `Export` bugs

### DIFF
--- a/Highschool/Euler_line.v
+++ b/Highschool/Euler_line.v
@@ -5,6 +5,8 @@ Require Export GeoCoq.Highschool.midpoint_thales.
 Require Export GeoCoq.Highschool.concyclic.
 Require Export GeoCoq.Highschool.gravityCenter.
 
+Import concyclic.
+
 Section Euler_line.
 
 Context `{TE:Tarski_euclidean}.

--- a/Highschool/bisector.v
+++ b/Highschool/bisector.v
@@ -1,5 +1,6 @@
 Require Export GeoCoq.Tarski_dev.Ch13_1.
 Require Export GeoCoq.Highschool.triangles.
+Require Import GeoCoq.Tarski_dev.Ch12_parallel.
 
 Section Bisector.
 

--- a/Meta_theory/Continuity/elementary_continuity_props.v
+++ b/Meta_theory/Continuity/elementary_continuity_props.v
@@ -4,6 +4,8 @@ Require Export GeoCoq.Tarski_dev.Annexes.sums.
 
 Require Import GeoCoq.Utils.all_equiv.
 
+Import circles.
+
 Section Elementary_Continuity_Props.
 
 Context `{TnEQD:Tarski_neutral_dimensionless_with_decidable_point_equality}.

--- a/Meta_theory/Models/tarski_to_euclid.v
+++ b/Meta_theory/Models/tarski_to_euclid.v
@@ -4,6 +4,8 @@ Require Export GeoCoq.Axioms.continuity_axioms.
 Require Export GeoCoq.Meta_theory.Continuity.elementary_continuity_props.
 Require Export GeoCoq.Meta_theory.Parallel_postulates.parallel_postulates.
 
+Import euclidean_axioms.
+
 Section Tarski_neutral_to_Euclid_neutral.
 
 Context `{TnEQD:Tarski_neutral_dimensionless_with_decidable_point_equality}.

--- a/Tarski_dev/Annexes/inscribed_angle.v
+++ b/Tarski_dev/Annexes/inscribed_angle.v
@@ -2,6 +2,8 @@ Require Export GeoCoq.Tarski_dev.Annexes.circles.
 Require Export GeoCoq.Tarski_dev.Annexes.half_angles.
 Require Export GeoCoq.Tarski_dev.Ch12_parallel_inter_dec.
 
+Import circles.
+
 Section Inscribed_angle.
 
 Context `{TE:Tarski_euclidean}.

--- a/Tarski_dev/Ch16_coordinates_with_functions.v
+++ b/Tarski_dev/Ch16_coordinates_with_functions.v
@@ -3,9 +3,9 @@ Require Import Ring.
 Require Import Field.
 Require Import Nsatz.
 Require Import Rtauto.
-Require Import GeoCoq.Tarski_dev.Annexes.midpoint_theorems.
 Require Export GeoCoq.Tarski_dev.Ch16_coordinates.
 Require Import GeoCoq.Tarski_dev.Ch15_pyth_rel.
+Require Import GeoCoq.Tarski_dev.Annexes.midpoint_theorems.
 
 Ltac cnf2 f :=
   match f with


### PR DESCRIPTION
See https://github.com/coq/coq/issues/10474 and https://github.com/coq/coq/issues/10480

This is in preparation for coq/coq#10476 which fixes these two bugs, and is backward compatible (tested on Coq's master).