### PR TITLE
Fix build of GeoCoq with math-comp master.

### DIFF
--- a/Meta_theory/Models/POF_to_Tarski.v
+++ b/Meta_theory/Models/POF_to_Tarski.v
@@ -429,7 +429,7 @@ move=> k_neq0; rewrite /extension /contraction.
 suffices: (k*:(k^-1 *: (y - x) + x) == k*:z) = (k^-1 *: (y - x) + x == z).
   move<-; rewrite scalerDr scalerA divff // scale1r eq_sym -subr_eq.
   by rewrite -subr_eq opprK -scalerBr.
-rewrite -subr_eq0 -[X in _ = X]subr_eq0 -scalerBr scaler_eq0.
+rewrite -[k *: _ == _]subr_eq0 -[X in _ = X]subr_eq0 -scalerBr scaler_eq0.
 by move/negPf: k_neq0 ->; rewrite orFb.
 Qed.
 


### PR DESCRIPTION
For some reason the matching behavior has changed upstream, we must
now use a more robust rewrite pattern selection.

See
https://github.com/math-comp/math-comp/pull/400#issuecomment-548054661
for possible additional comments.