### PR TITLE
Fix for Coq PR 13986

### DIFF
--- a/Utils/all_equiv.v
+++ b/Utils/all_equiv.v
@@ -1,4 +1,5 @@
 Require Export List.
+Require Lt.
 
 Definition all_equiv (l: list Prop) :=
   forall x y, In x l -> In y l -> (x <-> y).


### PR DESCRIPTION
In an effort https://github.com/coq/coq/pull/13986 to streamline Coq's `List.v`, dependencies on `Arith` modules are removed.
Therefore, importing `List` will not provide `Arith` functionality. Resulting issues are fixed by this PR.