### PR TITLE
proves [Equivalence eq] instead of assuming it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Makefile
 *.glob
 *.v.d
 *.aux
+*.vok
+*.vos

--- a/Utils/sets.v
+++ b/Utils/sets.v
@@ -20,7 +20,17 @@ Module SetOfSetsOfPositiveOrderedType <: OrderedType.
 
   Definition eq := S.Equal.
 
-  Include IsEq.
+  Lemma eq_equiv : Equivalence eq.
+  Proof.
+  split; intro; intros.
+
+    reflexivity.
+
+    symmetry.
+    assumption.
+
+    etransitivity; eassumption.
+  Qed.
 
   Definition eqb := S.equal.
 
@@ -70,7 +80,10 @@ Module SetOfPairsOfPositiveOrderedType <: OrderedType.
   Definition eq (t1 t2 : t) :=
     Pos.eq (fstpp(t1)) (fstpp(t2)) /\ Pos.eq (sndpp(t1)) (sndpp(t2)).
 
-  Include IsEq.
+  Lemma eq_equiv : Equivalence eq.
+  Proof.
+  split; repeat intros []; split; congruence.
+  Qed.
 
   Definition eqb (t1 t2 : t) :=
     Pos.eqb (fstpp(t1)) (fstpp(t2)) && Pos.eqb (sndpp(t1)) (sndpp(t2)).


### PR DESCRIPTION
Running the `Print Assumptions` command on some theorems (such as `Tarski_dev/Ch15_lengths/pythagoras`) gives a list of axioms that include the following two, but those two probably do not need to be axioms. This PR aims at fixing that.

```
sets.SetOfSetsOfPositiveOrderedType.eq_equiv
sets.SetOfPairsOfPositiveOrderedType.eq_equiv
```