### PR TITLE
upgrading to rocq9.0.0 and mathcomp2.4.0

### DIFF
--- a/theories/Algebraic/Counter_models/Planar/counter_model_euclid.v
+++ b/theories/Algebraic/Counter_models/Planar/counter_model_euclid.v
@@ -170,7 +170,7 @@ rewrite divff ?mulf_neq0 ?omd_eq0//.
 rewrite eq_sym mulrC !mulrA expr2.
 rewrite -[(t_aq * t_aq)^-1 * t_aq * t_aq ]mulrC mulrA.
 rewrite -[t_aq/(t_aq*t_aq)*t_aq]mulrC mulrA divff ?mulf_neq0 ?omd_eq0 //.
-rewrite mul1r invfM mulrC !mulrA mulrAC mulrC !mulrA mulrAC.
+rewrite mul1r invfM mulrC !mulrA mulrAC [t_pp / t_aa * t_aa / t_qq ]mulrC !mulrA mulrAC.
 rewrite -!mulrA divff ?omd_eq0 //.
 rewrite mulr1 eq_sym !mulrA mulr1 -!expr2 /k.
 rewrite -eqr_sqrt ?mulr_ge0 ?invr_ge0 ?expr2 ?mulr_ge0 ?omd_ge0 //.
@@ -254,7 +254,7 @@ by rewrite !subrr mulr0 mul0r eqxx.
 move=> /eqP /negPf NX0 /eqP /negPf NX1.
 rewrite -subr_eq0 opprD addrCA -[_-_]addrA -mulrBl addrCA addrA -mulrBl -[X in _ + X]opprK subr_eq0.
 rewrite Bool.andb_comm.
-rewrite -subr_eq0 opprD addrCA -[_-_]addrA -mulrBl addrCA addrA -mulrBl -[X in _ + X]opprK subr_eq0.
+rewrite -[(# b 0 0 * e 0 0 + # b 0 1 * e 0 1 == # c 0 0 * e 0 0 + # c 0 1 * e 0 1) ]subr_eq0 opprD addrCA -[_-_]addrA -mulrBl addrCA addrA -mulrBl -[X in _ + X]opprK subr_eq0.
 move=> /andP[/eqP H4 /eqP H5].
 suffices: (# a 0 0 - # b 0 0) * e 0 0 * -(# b 0 1 - # c 0 1) * e 0 1 ==
           (# b 0 0 - # c 0 0) * e 0 0 * -(# a 0 1 - # b 0 1) * e 0 1.

--- a/theories/Algebraic/Counter_models/nD/counter_model_cong_inner_transitivity.v
+++ b/theories/Algebraic/Counter_models/nD/counter_model_cong_inner_transitivity.v
@@ -42,6 +42,7 @@ Lemma segment_construction : segment_constructionP point bet cong.
 Proof.
 rewrite /segment_constructionP /bet /cong=> ? b.
 exists b; rewrite eqxx; intuition auto with bool.
+apply/orP; by right.
 Qed.
 
 Lemma five_segment : five_segmentP point bet cong.

--- a/theories/Algebraic/Counter_models/nD/counter_model_euclid.v
+++ b/theories/Algebraic/Counter_models/nD/counter_model_euclid.v
@@ -469,7 +469,7 @@ have: 1 == (l*1+(1-l)*1) by
   rewrite !mulr1 addrCA subrr addr0.
 move=> /eqP l_eq.
 rewrite {1}l_eq -[l*1 + _ + _]addrA -mulrBr addrAC -mulrBr.
-rewrite omd_ca omd_cb mulrDr mulrDr.
+rewrite omd_ca omd_cb mulrDr [(1 - l) * ((1 - l) * omd a a + l * omd a b)]mulrDr.
 rewrite addrACA [X in X + _]addrC mulrA -expr2.
 rewrite addrA addrAC [(1 - l) * (l * omd a b)]mulrCA.
 rewrite -[X in X +_ == _]addrA addrAC mulrA -expr2.
@@ -489,7 +489,11 @@ rewrite [X in _ - X]mulrC -!mulrA.
 rewrite [X in _ - X]mulrC -!mulrA.
 rewrite [X in _ - X]mulrC -!mulrA.
 rewrite -mulrBr mulf_eq0 omd_eq0 orFb.
-rewrite subr_eq0 !mulrA mulrAC mulrC -!mulrA -expr2.
+rewrite subr_eq0 !mulrA mulrAC. rewrite [omd b c ^- 2 /
+(1 +
+ Num.sqrt (1 - omd a a * omd b b / omd a b ^+ 2) *
+ Num.sqrt (1 - omd b b * omd c c / omd b c ^+ 2)) ^+ 2 * 
+omd b b * omd b b / omd a b ^+ 2]mulrC -!mulrA -expr2.
 rewrite -!exprVn -!exprMn eqf_sqr.
 suffices: ((omd a c)^-1 == (* We now this is the right equality *)
   ((omd a b)^-1 *
@@ -511,14 +515,14 @@ rewrite -!mulrA -!invfM divf_eq1 ?mulf_neq0 ?omd_eq0 //.
 rewrite -subr_eq0 addrAC addr_eq0.
 move: betS_abc=> /betSP[bet_eq betR_gt0 betR_lt1].
 move/eqP: bet_eq.
-rewrite eq_sym scalerBr -subr_eq0.
+rewrite eq_sym scalerBr -[betR (# a) (# b) (# c) *: # c - betR (# a) (# b) (# c) *: # a == # b - # a]subr_eq0.
 rewrite  -addrA addr_eq0 opprD !opprK.
 have: (betR (#a) (#b) (#c))^-1 != 0
   by rewrite lt0r_neq0 ?invr_gt0.
 move=> l_neq0.
 rewrite (scaler_eq _ _ l_neq0).
 rewrite scalerDr !scalerA mulrC divff ?lt0r_neq0 // !scale1r.
-rewrite scalerBr [_ - _]addrC addrA -{1}[#a]scale1r -scalerBl.
+rewrite scalerBr [((betR (# a) (# b) (# c))^-1 *: # b - (betR (# a) (# b) (# c))^-1 *: # a)]addrC addrA -{1}[#a]scale1r -scalerBl.
 move: l_neq0 ;
 set l := (betR (#a) (#b) (#c))^-1 => l_neq0 /eqP c_eq.
 have: (omd a b * omd b c - omd b b * omd a c ==
@@ -558,9 +562,9 @@ have: (omd b c ^+ 2 - omd b b * omd c c) ==
     have:  1 == (1-l)*1 +(l*1)
       by rewrite !mulr1  addrAC -addrA subrr addr0.
     move=> /eqP one_eq ; rewrite{1}one_eq.
-    rewrite !opprD !addrA addrAC addrC !addrA -!addrA -mulrBr.
+    rewrite !opprD !addrA addrAC addrC !addrA  -!addrA -mulrBr.
     rewrite !addrA [ X in X + _]addrC -mulrBr.
-    rewrite omd_cb omd_ca mulrDr mulrDr.
+    rewrite omd_cb omd_ca mulrDr [l * ((1 - l) * omd a b + l * omd b b)]mulrDr.
     rewrite mulrA -expr2 [l * ((1 - l) * omd a b)]mulrCA.
     rewrite [l * (l * omd b b)]mulrA -expr2.
     rewrite [(1 - l) * (l * omd a b)]mulrA.
@@ -712,7 +716,7 @@ move: ca_lt1 ; rewrite !mxE //.
 move: a_in_disk ; rewrite !mxE //.
 rewrite !mulr1 !mulrBl !mulrBr !mul1r !mulr1.
 rewrite [r * r + (r -r * r)]addrCA subrr addr0.
-rewrite [(1 - r) - (r - r * r)]addrC addrA addrC.
+rewrite [(1 - r) - (r - r * r)]addrC. rewrite [r + (r - r * r) + (- (r - r * r) + (1 - r))]addrA addrC.
 rewrite -[r + (r - r * r) - (r - r * r)]addrA subrr addr0.
 by rewrite addrAC -addrA subrr addr0 lexx.
 Qed.
@@ -798,7 +802,7 @@ have: omd c c == (
   move=> /eqP one_eq ; rewrite{1}one_eq.
   rewrite !opprD !addrA addrAC addrC !addrA -!addrA -mulrBr.
   rewrite !addrA [ X in X + _]addrC -mulrBr.
-  rewrite omd_cb omd_ca mulrDr mulrDr.
+  rewrite omd_cb omd_ca. rewrite mulrDr. rewrite [l * ((1 - l) * omd a b + l * omd b b)]mulrDr.
   rewrite mulrA -expr2 [l * ((1 - l) * omd a b)]mulrCA.
   rewrite [l * (l * omd b b)]mulrA -expr2.
   rewrite [(1 - l) * (l * omd a b)]mulrA.
@@ -844,7 +848,7 @@ have: omd c d == (1-l) * omd a d + l * (omd b d).
 move=> /eqP ->.
 rewrite [(_ + _)/omd a d]mulrDl -[X in (X+_)^+2]mulrA.
 rewrite divff ?omd_eq0 // mulr1 expr2 mulrDl mulrDr -expr2.
-rewrite mulrDr -expr2 -[l* omd _ _ / omd _ _]mulrA exprMn.
+rewrite [l * omd b d / omd a d * (1 - l + l * omd b d / omd a d)]mulrDr. rewrite -expr2 -[l* omd _ _ / omd _ _]mulrA exprMn.
 rewrite [X in _ + _ + (X + _)]mulrC eq_sym.
 rewrite ![mu^+2 * (_ +_)]mulrDr exprMn exprVn mulrCA.
 rewrite divff; last by rewrite expr2 mulf_neq0.
@@ -917,7 +921,10 @@ rewrite invfM invfM mulrA mulrA mulrA mulrA mulrC mulrA.
 rewrite mulrA mulrA -mulrA divff ?omd_eq0 // mulr1.
 rewrite mulrACA mulrA mulrC mulrA mulrA mulrA mulrC.
 rewrite mulrA mulrA mulrA mulrA -mulrA divff ?l_neq0 //.
-rewrite mulr1 mulrC mulrA mulrA mulrAC mulrC mulrA mulrA.
+rewrite mulr1 mulrC. 
+rewrite mulrA. rewrite mulrA. rewrite mulrAC.
+rewrite [omd a a / l / omd a b * (1 - l)]mulrC.
+rewrite mulrA mulrA.
 rewrite !opprD addrA -[-_-_-_+_]addrA [X in -_-_+X]addrC.
 rewrite subrr addr0 addrC addrA addrA -addrA [X in 1 -_+X]addrC.
 by rewrite subrr addr0 eqxx.
@@ -1007,7 +1014,7 @@ have : (1-l)/mu == (1-l')/mu'.
     rewrite add2r_eq.
     rewrite mulrAC mulrC mulrA mulrA [_^-1*_]mulrC.
     rewrite eq_sym.
-    by rewrite [X in X == _]mulrAC mulrC !mulrA [_^-1*_]mulrC.
+    by rewrite [X in X == _]mulrAC [(1 - l) * omd a a / omd a b / l ]mulrC !mulrA [_^-1*_]mulrC.
     rewrite -subr_eq0 opprK => /negPn /negPf H1.
     move: H1.
     rewrite lt0r_neq0 //.
@@ -1090,7 +1097,7 @@ Proof.
 move=> a_neq0 d_ge0 r1 r2.
 have: 4%:R * a * c * (2%:R^-1 / a) ^+ 2 == c / a.
   rewrite exprMn !exprVn mulrCA !mulrA [2%:R ^- 2 * 4%:R]mulrC.
-  rewrite /GRing.natmul /= expr2 mulrDl mul1r !addrA.
+  rewrite /GRing.natmul /= expr2.  rewrite [((1 + 1) * (1 + 1))]mulrDl mul1r !addrA.
   rewrite divff ?lt0r_neq0 ?addr_gt0 ?ltr01 //.
   rewrite mul1r expr2 mulrAC invfM mulrA divff //.
   by rewrite mul1r mulrC.
@@ -1352,12 +1359,12 @@ rewrite !mul1r !norm_sqr !seg_aux7 mulrBr.
 rewrite [omd b b /dist c d]mulrC.
 rewrite -![(dist c d)^-1 * _ * _]mulrA.
 rewrite -mulrBr [omd a b * ( _ -_)]mulrBr.
-rewrite mulrDl mulrBl -expr2 -[_^+2/_]invrK.
+rewrite mulrDl [(omd a b * omd b b - omd a b * omd a b) / (omd a a * omd b b)]mulrBl -expr2 -[_^+2/_]invrK.
 rewrite [(_^+2/_)^-1]invf_div /omd -/(dist_v _ _).
 rewrite -!/(omd _ _) -/(dist _ _).
 rewrite -mulrA mulrBl [omd b b * _]mulrC divff ?mulf_neq0 ?omd_eq0 //.
 rewrite mulrAC [_ * omd b b]mulrC [(omd b b * _)^-1]invfM.
-rewrite mulrA divff ?omd_eq0 // mul1r mulrC.
+rewrite mulrA divff ?omd_eq0 // mul1r [(omd a a)^-1 * omd a b]mulrC.
 rewrite mulrA -[_*_/omd b b]mulrA divff ?omd_eq0 //.
 by rewrite mulr1 addrA eqxx.
 Qed.
@@ -1413,15 +1420,15 @@ Proof.
 apply /eqP.
 rewrite eq_sym.
 rewrite exprMn exprVn ![_ + dist c d ^-2 * _]addrAC.
-rewrite -mulrDr /GRing.natmul /= mulrDl mulrDl -{1}[1]mulr1.
-rewrite opprD addrA -mulrA -mulrBr addrA.
+rewrite -mulrDr. rewrite /GRing.natmul /=. rewrite [(1 + 1) * omd a b]mulrDl. rewrite [(1 * omd a b + 1 * omd a b) / omd a a]mulrDl. rewrite -{1}[1]mulr1.
+rewrite opprD. rewrite [(1 * 1 + (- (1 * omd a b / omd a a) - 1 * omd a b / omd a a))]addrA. rewrite -mulrA. rewrite -mulrBr. rewrite addrA.
 rewrite [_-1* (omd a b /omd a a)]addrAC.
 rewrite [(omd a b/omd a a)^+2]expr2 -mulrBl.
 rewrite [_ + (1 * _)]addrC -[X in (1*_)+X]opprK.
 rewrite -[- ((omd a b/omd a a -1) * _)]mulNr opprB.
 rewrite [X in 1 * _ - X]mulrC -mulrBl -expr2 -exprVn.
 rewrite ![_+ (1 + 1) / dist c d * (omd a b / omd a a)]addrAC.
-rewrite mulrDl mulrDl mul1r addrA.
+rewrite [(1 + 1) / dist c d]mulrDl. rewrite [(1 / dist c d + 1 / dist c d) * (omd a b / omd a a)]mulrDl. rewrite mul1r. rewrite addrA.
 rewrite  -[_ + _ + (dist c d)^-1 * _ -_]addrA -mulrBr.
 rewrite -{3}[omd a b / omd a a]mul1r -mulrBl.
 rewrite [_+_+ (dist c d)^-1 * _]addrAC -[_+_+_-(dist c d)^-1 * _]addrA.
@@ -1487,7 +1494,13 @@ rewrite opprD !addrA ![_-(dist c d)^-1 / dist a b]addrAC.
 rewrite -exprVn expr2 -mulrBl.
 rewrite ![_+((dist a b)^-1 - (dist c d)^-1)*_]addrAC.
 rewrite -mulrDr !addrA.
-rewrite [X in _-X==_]mulrA -addrA.
+rewrite [X in _-X==_]mulrA. 
+rewrite -[((dist a b)^-1 - (dist c d)^-1) *
+((dist a b)^-1 - omd a b / omd a a + omd b b / omd a a - omd a b / omd a a) +
+dist c d ^- 2 * (omd b b / omd a a + 1 - omd a b / omd a a - omd a b / omd a a) -
+(dist c d)^-1 / dist a b * - (omd a b / omd a a) -
+(dist c d)^-1 / dist a b * (1 - omd a b / omd a a) -
+(dist c d)^-1 / dist a b * (omd b b / omd a a) ]addrA.
 rewrite -![- ((dist c d)^-1 / dist a b * _)]mulrN.
 rewrite -mulrDr -addrA -mulrDr !opprD !opprK !addrA.
 rewrite -[dist c d ^- 2 *_]opprK -[-(dist c d ^- 2 *_)]mulrN.
@@ -1644,7 +1657,7 @@ have: (f' *m (f')^T)0 0 <1.
     move=> ?.
     by rewrite -norm_sqr expr2 mulr_ilt1 ?norm_ge0.
   rewrite /f'/extension invrK scalerDl scale1r addrA.
-  rewrite -addrA [-#a+#a]addrC subrr addr0.
+  rewrite -[eps *: (# b - # a) + # b - # a + # a]addrA [-#a+#a]addrC subrr addr0.
   apply le_lt_trans with (norm(eps*:(#b-#a)) + norm(#b)).
     exact: triangle_ineq.
   rewrite /norm -scalemxAl dotC -scalemxAl scalerA mxE.
@@ -1680,7 +1693,7 @@ move: one_side_E2'=> [|bet_E2'ab].
 exact: (@cong_inner_transitivity_vector (# b) E1' (# b) E2' (#c) (#d)).
 rewrite point_vector_neq.
 rewrite /=/f'/extension invrK scalerDl scale1r.
-rewrite !addrA -addrA [-#a+#a]addrC subrr addr0 -subr_eq0.
+rewrite !addrA -[eps *: (# b - # a) + # b - # a + # a]addrA [-#a+#a]addrC subrr addr0 -subr_eq0.
 rewrite -addrA subrr addr0 scaler_eq0 subr_eq0 [#b==#a]eq_sym.
 by rewrite Bool.negb_orb lt0r_neq0.
 Qed.
@@ -2052,13 +2065,14 @@ rewrite orbF eqf_sqr /omd_v /i' !nth_basis //.
 rewrite !dimensional_axioms.nth_basis // iP.
 rewrite -!scalemxAl mulNmx dotC (dotC (delta_mx 0 0)) -!scalemxAl.
 rewrite !trmx_delta !mul_delta_mx_0 ?mxE ?(mulr0, oppr0) ?addr0 ?eqxx //.
+
 - apply /eqP => HF.
+have: val (@inord n.+1 1) = @ord0 n.+1 by rewrite HF.
+by rewrite val_insubd.
+apply /eqP => HF.
   have: val (@inord n.+1 j) = val (@inord n.+1 k) by rewrite HF.
   rewrite !val_insubd jP kP => jkE.
   by suff // : (j < k)%N by rewrite jkE ltnn.
-apply /eqP => HF.
-have: val (@inord n.+1 1) = @ord0 n.+1 by rewrite HF.
-by rewrite val_insubd.
 Qed.
 
 Lemma lower_dim_holds :
@@ -2250,7 +2264,7 @@ rewrite divff ?mulf_neq0 ?omd_eq0//.
 rewrite eq_sym mulrC !mulrA expr2.
 rewrite -[(t_aq * t_aq)^-1 * t_aq * t_aq ]mulrC mulrA.
 rewrite -[t_aq/(t_aq*t_aq)*t_aq]mulrC mulrA divff ?mulf_neq0 ?omd_eq0 //.
-rewrite mul1r invfM mulrC !mulrA mulrAC mulrC !mulrA mulrAC.
+rewrite mul1r invfM mulrC !mulrA mulrAC. rewrite [t_pp / t_aa * t_aa / t_qq ]mulrC !mulrA mulrAC.
 rewrite -!mulrA divff ?omd_eq0 //.
 rewrite mulr1 eq_sym !mulrA mulr1 -!expr2 /k.
 rewrite -eqr_sqrt ?mulr_ge0 ?invr_ge0 ?expr2 ?mulr_ge0 ?omd_ge0 //.
@@ -2749,7 +2763,7 @@ case: pickP => /= [z|/all_v_neq0 H].
   rewrite (@ord_inj _ (Ordinal p) 1) // =>_.
   rewrite addr0 ler_pdivlMr.
   rewrite mulrBr mul1r divff ?add11_neq0 //.
-  rewrite -subr_le0 mulrDl !mul1r addrAC -!addrA subrr addr0.
+  rewrite -subr_le0 mulrDl !mul1r [# x 0 1 + # x 0 1 - 1]addrAC -!addrA subrr addr0.
   rewrite subr_le0 ltW // bet_abx_x01_lt1 //.
   by rewrite subr_gt0 bet_abx_x01_gt.
 exfalso; apply H; rewrite subr_eq0 a'_eq0.

--- a/theories/Algebraic/Counter_models/nD/counter_model_five_segment.v
+++ b/theories/Algebraic/Counter_models/nD/counter_model_five_segment.v
@@ -94,7 +94,9 @@ rewrite /bet' {1}/bet betS_neq13; case: (a =P c)=> [->|/eqP neq_ac].
 rewrite /betE; case: (a =P b)=> [->|/eqP neq_ab]; first by rewrite !bet_xxa.
 case: (b =P c)=> [->|/eqP neq_bc /=]; first by rewrite !bet_axx.
 rewrite andbT /bet /betE /betS eq_head_behead => /andP[/andP[headP beheadP] bP].
-have: (@eq_op (GRing.Zmodule.eqType (matrix_zmodType R 1 1))
+have: (@eq_op (GRing_Nmodule__to__eqtype_Equality
+        (matrix_matrix__canonical__GRing_Nmodule
+           (Num_RealField__to__GRing_Nmodule R) 1 1))
               ((head b)%:M - (head a)%:M)
               (betR a b c *: ((head c)%:M - (head a)%:M))).
   by apply /eqP/rowP => i; move/eqP: headP; rewrite ord1 /head !mxE eqxx.

--- a/theories/Algebraic/Counter_models/nD/counter_model_lower_dim.v
+++ b/theories/Algebraic/Counter_models/nD/counter_model_lower_dim.v
@@ -84,7 +84,7 @@ suff: free new_basis.
 - move => {}HF; suff {HF} : ~~ free new_basis by rewrite HF.
   rewrite /free size_tuple ltn_eqF // ltnS.
   apply: (leq_trans (dimvS (subvf <<new_basis>>))).
-  by rewrite dimvf /Vector.dim /= mul1n.
+  by rewrite dimvf /dim /= mul1n.
 suff: (forall (i : 'I_n.+2), new_basis`_i *m new_basis`_i^T <> 0) /\
       (forall (i j : 'I_n.+2), i <> j -> new_basis`_i *m new_basis`_j^T = 0).
 - move => {HF} [no_null_vec ortho]; apply /freeP => k kt0 j.

--- a/theories/Algebraic/Counter_models/nD/counter_model_upper_dim.v
+++ b/theories/Algebraic/Counter_models/nD/counter_model_upper_dim.v
@@ -304,7 +304,7 @@ suff: (ohead (enum p2) =
   by have -> : h = i by move: H; apply: Some_inj.
 move: i => _; rewrite /enum_mem -enumT 2?my_enum_ordSr -!cats1 filter_cat.
 rewrite filter_map filter_cat map_cat -catA -filter_map -!map_comp.
-set t_nil := @filter (Finite.sort (ordinal_finType (S (S (S n))))) _ _.
+set t_nil := @filter (Finite.sort (_ (* ordinal_finType *) (S (S (S n))))) _ _.
 have: (t_nil == [::]) => [|/eqP->]; rewrite ?cat0s.
 - rewrite /t_nil -size_eq0 -all_pred0 all_filter; apply /allP => x.
   rewrite -enumT /= => xP; move/mapP: xP => [] x0 /mapP [] x1 _ -> ->.

--- a/theories/Algebraic/Counter_models/nD/dimensional_axioms.v
+++ b/theories/Algebraic/Counter_models/nD/dimensional_axioms.v
@@ -488,7 +488,7 @@ case: (n =P O) => [n_ez|n_nz]; split; [|tauto|tauto|]; move => _.
     case: (x =P inord n.+1) => [_ /=|/eqP/negPf HF]; last first.
     * by exfalso; move/eqP: xP; rewrite !mxE /= -mulNrn HF mulr0n addr0.
     by rewrite mulr1n mulNr -mulrN -invrN opprB opprK.
-  move: (row_sum_delta p); rewrite big_ord_recr; set pl := BigOp.bigop _ _ _.
+  move: (row_sum_delta p); rewrite big_ord_recr; set pl := bigop.bigop _ _ _.
   suff /eqP plE : pl == 0.
   + move => {pE}; rewrite plE /= add0r /ord_max.
     have -> : Ordinal (ltnSn n.+1) = inord n.+1
@@ -501,7 +501,7 @@ case: (n =P O) => [n_ez|n_nz]; split; [|tauto|tauto|]; move => _.
     rewrite scaler_eq0 => /orP[|/eqP/matrixP HF]; last first.
     * by move/eqP: (HF 0 0); rewrite !mxE eqxx oner_eq0.
     rewrite -expr2 subr_eq0 sqrf_eq1 => /orP[|/eqP->]; last first.
-    * by rewrite !mxE eqxx mulr1.
+    * by rewrite !mxE !eqxx mulr1.
     move => /eqP p_maxE; move: pE; rewrite p_maxE scale1r => pE.
     by move: i_n_neq_p; rewrite pE /i_n nth_basis.
   rewrite /pl /= (eq_big_seq (fun i => 0)) /=.

--- a/theories/Algebraic/POF_to_Tarski.v
+++ b/theories/Algebraic/POF_to_Tarski.v
@@ -407,7 +407,7 @@ Lemma betS_sym a b c : betS a b c = betS c b a.
 Proof.
 rewrite /betS /betR !andb_assoc -(addrBDB b c a) -[c - a]opprB ratiorN oppr_gt0.
 case (a - c =P 0)=> [->|/eqP ?]; first by rewrite !ratiop0 ltxx !andbF.
-rewrite -add_ratio ?ratioNr ?ratiovv // andbAC subr_lt0 ltrNl ltrBrDl.
+rewrite -!add_ratio ?ratioNr ?ratiovv // andbAC subr_lt0 ltrNl ltrBrDl.
 by rewrite scaleNr -scalerN scalerBl scale1r -subr_eq !opprB !addrBDB subrr.
 Qed.
 
@@ -659,8 +659,8 @@ suff: (((k2 + k1 - k2 * k1) / (k2 - k2 * k1))^-1 *: (a - q) + q ==
   rewrite ?lt0r_neq0 ?subr_gt0 ?addrA ?bet_gt0' ?bet_lt1 //= ?subr_eq0;
   rewrite ?[k1 + k2]addrC ?bet_lt ?[k2 + k1]addrC ?bet_lt ?subr_gt0;
   rewrite 1?mulrC ?gtr_pMl //; by apply /eqP.
-rewrite [X in X - _]addrC eq_sym [X in X - _]addrC -!addrA !invf_div.
-rewrite -subr_eq [k2 * _]mulrC !addrA -addrA [k2 + k1]addrC.
+rewrite [X in X - _]addrC eq_sym [X in X - (k1*k2)]addrC -!addrA !invf_div.
+rewrite -subr_eq [k2 * _]mulrC !addrA -[_+p-q]addrA [k2 + k1]addrC.
 rewrite eq_div_scale ?bet_neq0' // scalerDr scalerA mulrCA mulfV ?bet_neq0' //.
 rewrite  mulr1 -subr_eq0 -[a - q]opprB scalerN !scalerBl !opprB.
 rewrite addrACA -[X in _ + X]addrA -!scaleNr -scalerDr addrBDB -addrCA addrAC.
@@ -772,7 +772,7 @@ Qed.
 
 Lemma congC a b c d: cong a b c d = cong b a d c.
 Proof.
-rewrite /cong -opprB mulNmx dotC -mulNmx 2?opprB eq_sym -opprB.
+rewrite /cong -opprB mulNmx dotC -mulNmx 2?opprB eq_sym -[d-c]opprB.
 by rewrite mulNmx [X in -X]dotC -mulNmx 2?opprB eq_sym.
 Qed.
 
@@ -790,7 +790,7 @@ Proof.
 move=> b1. have: betS c b a by rewrite betS_sym. rewrite betS_neq13; move: b1.
 move=> /betSP[E1 ? ?] /andP[/betSP[E2 ? ?]?]. apply /eqP; rewrite -opprB E1 E2.
 rewrite eq_div_scale /r ?lt0r_neq0 // sub_1_ratio ?subr_eq0 // opprB addrBDB.
-by rewrite /betR -scalerN opprB !scalerA mulrC -opprB ratioNr -ratiorN opprB.
+by rewrite /betR -scalerN opprB !scalerA mulrC -[b-c]opprB ratioNr -ratiorN opprB.
 Qed.
 
 Lemma betS_gt0 a b c (r := ratio (b - a) (c - a)) : betS a b c -> 0 < (1 - r) / r.
@@ -1056,8 +1056,8 @@ Lemma col_2D_aux_3 a b c :
   ((b 0 1 - a 0 1) * (c 0 0 - a 0 0) == (b 0 0 - a 0 0) * (c 0 1 - a 0 1)) =
   ((a 0 0 - b 0 0) * (b 0 1 - c 0 1) == (a 0 1 - b 0 1) * (b 0 0 - c 0 0)).
 Proof.
-rewrite -opprB mulNr -mulrN opprB eq_sym -opprB mulNr -mulrN opprB.
-rewrite -[X in _ * X](addrBDB _ (b 0 1)) -[X in _ == _ * X](addrBDB _ (b 0 0)).
+rewrite -opprB mulNr -mulrN opprB eq_sym -[b 0 0 - a 0 0]opprB mulNr -mulrN opprB.
+rewrite -[X in _ * X](addrBDB _ (b 0 1)) -[a 0 0 - c 0 0](addrBDB _ (b 0 0)).
 by rewrite mulrDr [X in _ == X]mulrDr mulrC add2r_eq.
 Qed.
 
@@ -1157,7 +1157,7 @@ rewrite -(cong_perp_aux1 a p m) -[p 0 1 - a 0 1](cong_perp_aux1 a p m).
 rewrite -(cong_perp_aux2 a p q) -[q 0 1 - a 0 1](cong_perp_aux2 a p) -!/m.
 rewrite -[p 0 0 - m 0 0]opprB; set x0 := m 0 0 - a 0 0; set y0 := m 0 0 - p 0 0.
 rewrite -[p 0 1 - m 0 1]opprB; set x1 := m 0 1 - a 0 1; set y1 := m 0 1 - p 0 1.
-rewrite !mulNr -subr_eq eq_sym -addrA [X in _ == X]addrC -subr_eq !subr_sqr.
+rewrite !mulNr -subr_eq eq_sym -[(x0 - y0) ^+ 2 + (x1 - y1) ^+ 2 - (x1 + y1) ^+ 2]addrA [X in _ == X]addrC -subr_eq !subr_sqr.
 rewrite eq_sym -opprB mulNr -sub0r subr_eq eq_sym !addrDBB [X in _ * X]addrC.
 rewrite !addrBDD !mulrnAl !mulrnAr -!mulrnA -mulrnDl mulrn_eq0 muln_eq0 /=.
 by rewrite addr_eq0=> /eqP E; rewrite -E addrC subrr.
@@ -1245,7 +1245,7 @@ Lemma upper_dim_aux (a b m : 'rV[R]_2) (c0 c1: R) :
 Proof.
 move=> /eqP E1 /eqP E2; move: E1 E2; rewrite !addr_eq0 -!mulNr.
 move=> /eqP E1 /eqP E2; apply /eqP; rewrite -(addrBBB (m 0 0)) eq_sym.
-by rewrite -(addrBBB (m 0 1)) mulrBr eq_sym mulrBr -E1 -E2.
+ by rewrite -[(b 0 1 - a 0 1) ](addrBBB (m 0 1)) mulrBr eq_sym mulrBr -E1 -E2.
 Qed.
 
 Lemma upper_dim a b c p q :
@@ -1394,7 +1394,7 @@ Lemma segment_construction a b c d :
 Proof.
 have [->|neq_ba] := eqVneq b a; [|move: neq_ba; rewrite -subr_eq0=> neq_ba].
   exists ((c - d) + a); rewrite /bet /cong betE_xxa; split=> //.
-  by rewrite -!addrA subrr addr0 -opprB mulNmx eq_sym dotC opprB -mulNmx opprB.
+  by rewrite -!addrA subrr addr0 -[d-c]opprB mulNmx eq_sym dotC opprB -mulNmx opprB.
 have [->|neq_dc] := eqVneq d c ; [|move: neq_dc; rewrite -subr_eq0=> neq_dc].
   by exists b; rewrite /bet /cong betE_axx !subrr mul0mx eqxx; split.
 exists (normv(d - c) / normv(b - a) *: (b - a) + b); rewrite /bet /cong; split.

--- a/theories/Coinc/Utils/arity.v
+++ b/theories/Coinc/Utils/arity.v
@@ -623,12 +623,12 @@ intros cp Default id n Hle; revert cp; induction n; intro cp.
 rewrite plus_n_0; simpl; reflexivity.
 rewrite circPermNCPOK.
 assert (H : id + n <= S m).
-  {
+  (*{*)
   apply (Nat.le_trans _ (id + S n)); auto.
   rewrite <- plus_n_Sm; apply Nat.le_succ_diag_r.
-  }
+  (*}*)
 assert (H' : id + n <= m)
-  by (apply le_S_n; transitivity (id + S n); intuition auto with arith).
+  by (apply le_S_n; transitivity (id + S n);  intuition).
 rewrite <- IHn; try assumption.
 rewrite <- plus_n_Sm.
 apply nthCircPerm2Eq; assumption.
@@ -700,11 +700,11 @@ revert cp; induction m; intro cp.
 apply circPermNIdFirst.
 assert (H : m <= n) by (do 2 (apply le_S_n); assumption).
 rewrite nthCircPerm2Eq; try assumption; clear H.
-assert (H : S m <= S (S n)) by intuition auto with arith.
+assert (H : S m <= S (S n)) by intuition.
 rewrite IHm; try assumption; clear H; clear IHm.
 rewrite <- circPermNCPOK.
 rewrite circPermPerm.
-assert (H : m + 1 <= S n) by (rewrite plus_n_1; intuition auto with arith).
+assert (H : m + 1 <= S n) by (rewrite plus_n_1; auto with arith).
 rewrite <- nthCircPermNAny; try assumption; clear H.
 rewrite plus_n_1; reflexivity.
 induction m.
@@ -1232,7 +1232,7 @@ induction n; intros cp1 cp2 appPred pred_perm_1 pred_perm_2 Hpred HPerm.
       apply nthCircPerm2 in Hnth; try assumption; clear H.
       apply le_S in Hle.
       rewrite <- Nat.succ_le_mono in Hle.
-      assert (H : S id >= 1) by intuition auto with arith.
+      assert (H : S id >= 1) by auto with arith.
       clear Hge; rename H into Hge.
       assert (H : appPred (consTailCP (tailCP cp1) (headCP cp1)))
         by (apply pred_perm_1; rewrite <- consHeadCPOK; assumption) ; clear Hpred; rename H into Hpred.

--- a/theories/Elements/OriginalProofs/lemma_extension.v
+++ b/theories/Elements/OriginalProofs/lemma_extension.v
@@ -34,15 +34,17 @@ assert (Cong P Q B D) by (conclude lemma_congruencesymmetric).
 assert (neq B D) by (conclude axiom_nocollapse).
 let Tf:=fresh in
 assert (Tf:exists J, CI J B B D) by (conclude postulate_Euclid3);destruct Tf as [J];spliter.
-assert (InCirc B J) by (conclude_def InCirc ).
+unshelve assert (InCirc B J) by (conclude_def InCirc ).
+exact A.
+exact A.
 let Tf:=fresh in
 assert (Tf:exists C E, (Col A B C /\ BetS A B E /\ OnCirc C J /\ OnCirc E J /\ BetS C B E)) by (conclude postulate_line_circle);destruct Tf as [C[E]];spliter.
 assert (Cong B E B D) by (conclude axiom_circle_center_radius).
 assert (Cong B E P Q) by (conclude lemma_congruencetransitive).
 close.
-Unshelve.
+(*Unshelve.
 exact A.
-exact A.
+exact A.*)
 Qed.
 
 End Euclid.

--- a/theories/Elements/OriginalProofs/lemma_localextension.v
+++ b/theories/Elements/OriginalProofs/lemma_localextension.v
@@ -15,14 +15,16 @@ intros.
 assert (eq B B) by (conclude cn_equalityreflexive).
 let Tf:=fresh in
 assert (Tf:exists J, CI J B B Q) by (conclude postulate_Euclid3);destruct Tf as [J];spliter.
-assert (InCirc B J) by (conclude_def InCirc ).
+unshelve assert (InCirc B J) by (conclude_def InCirc ).
+exact A.
+exact A.
 let Tf:=fresh in
 assert (Tf:exists C E, (Col A B C /\ BetS A B E /\ OnCirc C J /\ OnCirc E J /\ BetS C B E)) by (conclude postulate_line_circle);destruct Tf as [C[E]];spliter.
 assert (Cong B E B Q) by (conclude axiom_circle_center_radius).
 close.
-Unshelve.
+(*Unshelve.
 exact A.
-exact A.
+exact A.*)
 Qed.
 
 End Euclid.

--- a/theories/Elements/OriginalProofs/lemma_ondiameter.v
+++ b/theories/Elements/OriginalProofs/lemma_ondiameter.v
@@ -39,14 +39,16 @@ by cases on (BetS D N F \/ BetS F N M \/ eq F N).
  }
 {
  assert (eq N F) by (conclude lemma_equalitysymmetric).
- assert (InCirc N K) by (conclude_def InCirc ).
+ unshelve assert (InCirc N K) by (conclude_def InCirc ).
+exact M.
+exact M.
  close.
  }
 (* cases *)
 close.
-Unshelve.
+(*Unshelve.
 exact M.
-exact M.
+exact M.*)
 Qed.
 
 End Euclid.

--- a/theories/Elements/OriginalProofs/proposition_01.v
+++ b/theories/Elements/OriginalProofs/proposition_01.v
@@ -22,12 +22,16 @@ assert (Tf:exists D, (BetS B A D /\ Cong A D A B)) by (conclude lemma_localexten
 assert (Cong B A B A) by (conclude cn_congruencereflexive).
 assert (OutCirc D K) by (conclude_def OutCirc) .
 assert (eq B B) by (conclude cn_equalityreflexive).
-assert (InCirc B K) by (conclude_def InCirc ).
+unshelve assert (InCirc B K) by first [(conclude_def InCirc )].
+exact A.
+exact A.
 assert (Cong A B A B) by (conclude cn_congruencereflexive).
 assert (OnCirc B J) by (conclude_def OnCirc ).
 assert (OnCirc D J) by (conclude_def OnCirc ).
 assert (eq A A) by (conclude cn_equalityreflexive).
-assert (InCirc A J) by (conclude_def InCirc ).
+unshelve assert (InCirc A J) by (conclude_def InCirc ).
+exact A.
+exact A.
 let Tf:=fresh in
 assert (Tf:exists C, (OnCirc C K /\ OnCirc C J)) by (conclude postulate_circle_circle);destruct Tf as [C];spliter.
 assert (Cong A C A B) by (conclude axiom_circle_center_radius).
@@ -77,8 +81,8 @@ assert (~ Col A B C).
  }
 assert (Triangle A B C) by (conclude_def Triangle ).
 close.
-Unshelve.
-all: (exact A).
+(*Unshelve.
+all: (exact A).*)
 Qed.
 
 End Euclid.

--- a/theories/Elements/OriginalProofs/proposition_02.v
+++ b/theories/Elements/OriginalProofs/proposition_02.v
@@ -24,7 +24,9 @@ assert (eq B B) by (conclude cn_equalityreflexive).
 let Tf:=fresh in
 assert (Tf:exists J, CI J B B C) by (conclude postulate_Euclid3);destruct Tf as [J];spliter.
 
-assert (InCirc B J) by (conclude_def InCirc ).
+unshelve assert (InCirc B J) by (conclude_def InCirc ).
+exact A.
+exact A.
 assert (neq D B) by (forward_using lemma_NCdistinct).
 let Tf:=fresh in
 assert (Tf:exists P G, (Col D B P /\ BetS D B G /\ OnCirc P J /\ OnCirc G J /\ BetS P B G)) by (conclude postulate_line_circle);destruct Tf as [P[G]];spliter.
@@ -48,9 +50,9 @@ assert (Cong D G D L) by (conclude lemma_congruencesymmetric).
 assert (Cong B G A L) by (conclude lemma_differenceofparts).
 assert (Cong A L B C) by (conclude cn_congruencetransitive).
 close.
-Unshelve.
+(*Unshelve.
 exact A.
-exact A.
+exact A.*)
 Qed.
 
 End Euclid.


### PR DESCRIPTION
Fixing files in the directory Algebraic, to adapt to mathcomp2.4.0
minor changes related to the tactic 'intuition' and the command 'Unshelve' (replaced by the tactic 'unshelve')